### PR TITLE
Lazyly require BcryptDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.20.3](https://github.com/supercharge/framework/compare/v3.20.1...v3.20.2) - 2023-10-14
+
+### Updated
+- `@supercharge/hashing`
+    - require `BcryptDriver` inside the `createBcryptDriver` method to only import dependencies when needed. This will support Supercharge to use Bun (the new runtime) because it doesn’t reference a bcrypt_napi bridge
+- bump dependencies
+
+
 ## [3.20.2](https://github.com/supercharge/framework/compare/v3.20.1...v3.20.2) - 2023-08-24
 
 ### Updated

--- a/packages/hashing/src/hash-manager.ts
+++ b/packages/hashing/src/hash-manager.ts
@@ -1,7 +1,6 @@
 'use strict'
 
 import { Manager } from '@supercharge/manager'
-import { BcryptHasher } from './bcrypt-hasher'
 import { ScryptHasher } from './scrypt-hasher'
 import { Hasher } from '@supercharge/contracts'
 
@@ -27,6 +26,8 @@ export class HashManager extends Manager implements Hasher {
    * Create a bcrypt hasher instance.
    */
   protected createBcryptDriver (): Hasher {
+    const { BcryptHasher } = require('./bcrypt-hasher')
+
     return new BcryptHasher({
       rounds: this.config().get('hashing.bcrypt.rounds', 10)
     })


### PR DESCRIPTION
Requiring the `BcryptDriver` lazyly (inside the `createBcryptDriver` method) imports bcrypt-related dependencies only when needed.

This will support Bun (the new runtime) to run Supercharge projects because Bun doesn’t reference a bcrypt_napi bridge early on. The bcrypt_napi isn’t supported in Bun and would fail the project. This change should make it possible to use Bun seamlessly, with the premise of not using bcrypt.