### PR TITLE
Generic StateBag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 ### Updated
 - bump dependencies
+- `@supercharge/contracts`
+    - `StateBag`: add `exists` method to determine whether the state bag contains an entry `key`, no matter what value is assigned to the key
 
 ### Breaking Changes
 - all packages of the framework moved to ESM
 - require Node.js v20
+- `@supercharge/contracts`
+    - removed export `RequestStateData`, use `HttpStateData` instead
+    - `StateBag`: the `has(key)` method now determines whether the value for a given `key` is not `undefined`. If you want to check whether a given `key` is present in the state bag, independently from the value, use the newly added `exists(key)` method
+    - `StateBag`: the `isMissing(key)` method now determines whether a value for a given `key` is `undefined` (related to `has(key)`, because `isMissing` is doing the opposite of `has`)
 
 
 ## [3.20.4](https://github.com/supercharge/framework/compare/v3.20.3...v3.20.4) - 2023-10-15

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@supercharge/eslint-config-typescript": "~4.0.0",
     "@supercharge/tsconfig": "~7.0.0",
-    "@types/node": "~20.8.7",
+    "@types/node": "~20.8.9",
     "eslint": "~8.52.0",
     "lerna": "~7.4.1",
     "nx": "16.10.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@supercharge/macroable": "~2.0.1",
-    "@types/koa__router": "~12.0.2",
-    "@types/node": "~20.8.7",
+    "@types/koa__router": "~12.0.3",
+    "@types/node": "~20.8.9",
     "handlebars": "~4.7.8",
     "knex": "~3.0.1"
   },

--- a/packages/contracts/src/http/concerns/interacts-with-state.ts
+++ b/packages/contracts/src/http/concerns/interacts-with-state.ts
@@ -1,7 +1,7 @@
 
-import { StateBag } from './state-bag.js'
+import { StateBag, HttpStateData } from './state-bag.js'
 
-export interface InteractsWithState {
+export interface InteractsWithState<State = HttpStateData> {
   /**
    * Share a given `state` across HTTP requests. Any previously
    * set state will be merged with the given `state`.
@@ -11,6 +11,8 @@ export interface InteractsWithState {
    * response.share({ user: { id: 1, name: 'Marcus' } })
    * ```
    */
+  share<K extends keyof State> (key: K, value: State[K]): this
+  share (values: Partial<State>): this
   share (key: string | any, value?: any): this
 
   /**
@@ -23,5 +25,5 @@ export interface InteractsWithState {
    * // something like "{ app: {…}, user: {…} }"
    * ```
    */
-  state (): StateBag
+  state (): StateBag<State>
 }

--- a/packages/contracts/src/http/concerns/state-bag.ts
+++ b/packages/contracts/src/http/concerns/state-bag.ts
@@ -4,30 +4,35 @@
  * Extend this interface in a userland typing file and use TypeScript’s
  * declaration merging features to provide IntelliSense in the app.
  *
- * We can’t use a Record-like interface with an index signature, because the
- * index signature allows
+ * We’re not using a `Record`-like interface with an index signature, because
+ * the index signature would resolve all keys to the `any` type. Using the
+ * empty interface allows everyone to merge their interface definitions.
  */
-export type RequestStateData = any
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface HttpStateData {
+  //
+}
 
-export interface StateBag {
+export interface StateBag<State = HttpStateData> {
   /**
    * Returns the state object.
    */
-  all<K extends keyof RequestStateData> (...keys: K[]): Pick<RequestStateData, K>
+  all (): State
+  all<K extends keyof State> (...keys: K[]): Pick<State, K>
   all<R = Record<string, any>> (...keys: string[]): R
 
   /**
    * Returns the saved state for the given `name`.
    */
-  get<K extends keyof RequestStateData> (name: K): RequestStateData[K]
+  get<K extends keyof State> (name: K): State[K] extends undefined ? undefined : State[K]
   get<R = any> (name: string, defaultValue?: R): R
 
   /**
    * Add a key-value-pair to the shared state or an object of key-value-pairs.
    */
-  add<K extends keyof RequestStateData> (key: K, value: RequestStateData[K]): this
+  add<K extends keyof State> (key: K, value: State[K]): this
   add (key: string, value: any): this
-  add (values: RequestStateData): this
+  add (values: State): this
 
   /**
    * Merge the given `data` object with the existing shared state.
@@ -35,21 +40,27 @@ export interface StateBag {
   merge (data: Record<string, any>): this
 
   /**
+   * Determine whether the state bag contains an item for the given `key`.
+   */
+  exists<K extends keyof State> (key: K): K extends undefined ? false : true
+  exists (key: string): boolean
+
+  /**
    * Determine whether a shared state item exists for the given `name`.
    */
-  has<K extends keyof RequestStateData> (name: K): boolean
+  has<K extends keyof State> (name: K): State[K] extends undefined ? false : true
   has (name: string): boolean
 
   /**
    * Determine whether the shared state is missing an item for the given `name`.
    */
-  isMissing<K extends keyof RequestStateData> (name: K): boolean
+  isMissing<K extends keyof State> (name: K): State[K] extends undefined ? true : false
   isMissing (name: string): boolean
 
   /**
    * Remove the shared state item for the given `name`.
    */
-  remove<K extends keyof RequestStateData> (name: K): this
+  remove<K extends keyof State> (name: K): this
   remove (name: string): this
 
   /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -33,7 +33,7 @@ export { RequestCookieBuilder, RequestCookieBuilderCallback, ResponseCookieBuild
 export { CorsConfig, CorsOptions } from './http/cors-config.js'
 export { InteractsWithContentTypes } from './http/concerns/interacts-with-content-types.js'
 export { InteractsWithState } from './http/concerns/interacts-with-state.js'
-export { StateBag, RequestStateData } from './http/concerns/state-bag.js'
+export { StateBag, HttpStateData } from './http/concerns/state-bag.js'
 export { FileBag } from './http/file-bag.js'
 export { InputBag } from './http/input-bag.js'
 export { ParameterBag } from './http/parameter-bag.js'

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -51,7 +51,7 @@
 		"@types/formidable": "~3.4.4",
 		"@types/koa": "~2.13.10",
 		"@types/koa__cors": "~4.0.2",
-		"@types/koa__router": "~12.0.2",
+		"@types/koa__router": "~12.0.3",
 		"@types/koa-static": "~4.0.3",
 		"c8": "~8.0.1",
 		"deepmerge": "~4.3.1",

--- a/packages/http/src/server/interacts-with-state.ts
+++ b/packages/http/src/server/interacts-with-state.ts
@@ -2,7 +2,7 @@
 import { StateBag } from './state-bag.js'
 import { tap } from '@supercharge/goodies'
 import { RouterContext } from '@koa/router'
-import { InteractsWithState as InteractsWithStateContract, RequestStateData } from '@supercharge/contracts'
+import { InteractsWithState as InteractsWithStateContract, HttpStateData } from '@supercharge/contracts'
 
 export class InteractsWithState implements InteractsWithStateContract {
   /**
@@ -28,10 +28,10 @@ export class InteractsWithState implements InteractsWithStateContract {
    * Share a given `state` across HTTP requests. Any previously
    * set state will be merged with the given `state`.
    */
-  share<K extends keyof RequestStateData> (key: K, value: RequestStateData[K]): this
+  share<K extends keyof HttpStateData> (key: K, value: HttpStateData[K]): this
   share (key: string, value: any): this
-  share (values: RequestStateData): this
-  share<K extends keyof RequestStateData> (key: K | string | RequestStateData, value?: any): this {
+  share (values: Partial<HttpStateData>): this
+  share<K extends keyof HttpStateData> (key: K | string | HttpStateData, value?: any): this {
     return tap(this, () => {
       this.state().add(key, value)
     })

--- a/packages/http/test/state.js
+++ b/packages/http/test/state.js
@@ -77,26 +77,39 @@ test('merge', () => {
     .toThrow('Invalid argument when merging state via "state().merge()". Expected an object. Received "string".')
 })
 
+test('exists', () => {
+  expect(new StateBag({ state: {} }).exists()).toBe(false)
+  expect(new StateBag({ state: {} }).exists('test')).toBe(false)
+  expect(new StateBag({ state: { a: 'b' } }).exists('c')).toBe(false)
+
+  expect(new StateBag({ state: { a: '' } }).exists('a')).toBe(true)
+  expect(new StateBag({ state: { a: 'b' } }).exists('a')).toBe(true)
+  expect(new StateBag({ state: { a: null } }).exists('a')).toBe(true)
+  expect(new StateBag({ state: { a: false } }).exists('a')).toBe(true)
+  expect(new StateBag({ state: { a: undefined } }).exists('a')).toBe(true)
+  expect(new StateBag({ state: { a: { b: { u: undefined } } } }).exists('a.b.u')).toBe(true)
+})
+
 test('has', () => {
   expect(new StateBag({ state: {} }).has()).toBe(false)
   expect(new StateBag({ state: {} }).has('test')).toBe(false)
   expect(new StateBag({ state: { a: 'b' } }).has('c')).toBe(false)
+  expect(new StateBag({ state: { a: undefined } }).has('a')).toBe(false)
 
   expect(new StateBag({ state: { a: '' } }).has('a')).toBe(true)
   expect(new StateBag({ state: { a: 'b' } }).has('a')).toBe(true)
   expect(new StateBag({ state: { a: null } }).has('a')).toBe(true)
   expect(new StateBag({ state: { a: false } }).has('a')).toBe(true)
-  expect(new StateBag({ state: { a: undefined } }).has('a')).toBe(true)
 })
 
 test('has: works with nested fields', () => {
   expect(new StateBag({ state: { a: { b: { c: true } } } }).has('a')).toBe(true)
   expect(new StateBag({ state: { a: { b: { c: true } } } }).has('a.b')).toBe(true)
+  expect(new StateBag({ state: { a: { b: { u: undefined } } } }).has('a.b.u')).toBe(false)
 
   expect(new StateBag({ state: { a: { b: { e: '' } } } }).has('a.b.e')).toBe(true)
   expect(new StateBag({ state: { a: { b: { n: null } } } }).has('a.b.n')).toBe(true)
   expect(new StateBag({ state: { a: { b: { f: false } } } }).has('a.b.f')).toBe(true)
-  expect(new StateBag({ state: { a: { b: { u: undefined } } } }).has('a.b.u')).toBe(true)
 
   expect(new StateBag({ state: { a: { b: { c: true } } } }).has('a.c')).toBe(false)
   expect(new StateBag({ state: { a: { b: { c: true } } } }).has('a.b.d')).toBe(false)
@@ -106,22 +119,22 @@ test('isMissing', () => {
   expect(new StateBag({ state: {} }).isMissing()).toBe(true)
   expect(new StateBag({ state: {} }).isMissing('test')).toBe(true)
   expect(new StateBag({ state: { a: 'b' } }).isMissing('c')).toBe(true)
+  expect(new StateBag({ state: { a: undefined } }).isMissing('a')).toBe(true)
 
   expect(new StateBag({ state: { a: '' } }).isMissing('a')).toBe(false)
   expect(new StateBag({ state: { a: 'b' } }).isMissing('a')).toBe(false)
   expect(new StateBag({ state: { a: null } }).isMissing('a')).toBe(false)
   expect(new StateBag({ state: { a: false } }).isMissing('a')).toBe(false)
-  expect(new StateBag({ state: { a: undefined } }).isMissing('a')).toBe(false)
 })
 
 test('isMissing: works with nested fields', () => {
   expect(new StateBag({ state: { a: { b: { c: true } } } }).isMissing('a')).toBe(false)
   expect(new StateBag({ state: { a: { b: { c: true } } } }).isMissing('a.b')).toBe(false)
+  expect(new StateBag({ state: { a: { b: { u: undefined } } } }).isMissing('a.b.u')).toBe(true)
 
   expect(new StateBag({ state: { a: { b: { e: '' } } } }).isMissing('a.b.e')).toBe(false)
   expect(new StateBag({ state: { a: { b: { n: null } } } }).isMissing('a.b.n')).toBe(false)
   expect(new StateBag({ state: { a: { b: { f: false } } } }).isMissing('a.b.f')).toBe(false)
-  expect(new StateBag({ state: { a: { b: { u: undefined } } } }).isMissing('a.b.u')).toBe(false)
 
   expect(new StateBag({ state: { a: { b: { c: true } } } }).isMissing('a.c')).toBe(true)
   expect(new StateBag({ state: { a: { b: { c: true } } } }).isMissing('a.b.d')).toBe(true)

--- a/packages/session/src/session-manager.ts
+++ b/packages/session/src/session-manager.ts
@@ -7,6 +7,15 @@ import { MemorySessionDriver } from './drivers/memory.js'
 import { CookieSessionDriver } from './drivers/cookie.js'
 import { Application, HttpContext, SessionDriver } from '@supercharge/contracts'
 
+/**
+ * Add HTTP state bindings for the session.
+ */
+declare module '@supercharge/contracts' {
+  export interface HttpStateData {
+    'session': Session | undefined
+  }
+}
+
 export class SessionManager extends Manager<Application> {
   /**
    * Stores the HTTP request instance. The cookie driver needs the request
@@ -49,8 +58,10 @@ export class SessionManager extends Manager<Application> {
    * Returns a new session instance for the given `request`.
    */
   createFrom (ctx: HttpContext): Session {
-    if (ctx.state().has('session')) {
-      return ctx.state().get('session') as Session
+    const existingSession = ctx.state().get('session')
+
+    if (existingSession) {
+      return existingSession
     }
 
     this.ctx = ctx


### PR DESCRIPTION
This pull request refactors the usage of an interface that allows developers to extend the shared values across a request lifecycle. We introduce and use the `HttpStateData` interface that can be extended in packages and applications:

```ts
declare module '@supercharge/contracts' {
    export interface HttpStateData {
        session: Session | undefined
    }
}
```