### PR TITLE
Error handler: switch error and ctx params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@
 - `@supercharge/http`
     - the `RequestHeaderBag` extends the `InputBag` which changes the behavior of the `has(key)` method: it returns `false` if the stored value is `undefined` and returns `true` otherwise
 
+    This pull request switches the parameters of the error report, handle, render method:
+- `@supercharge/core`
+    - switch the parameters of the error’s and error handler’s `report`, `handle`, `render` methods:
+    ```ts
+    // before
+    handle(ctx: HttpContext, error: Error)
+    report(ctx: HttpContext, error: Error)
+    render(ctx: HttpContext, error: Error)
+
+    // now
+    handle(error: Error, ctx: HttpContext)
+    report(error: Error, ctx: HttpContext)
+    render(error: Error, ctx: HttpContext)
+    ```
 
 
 ## [3.20.4](https://github.com/supercharge/framework/compare/v3.20.3...v3.20.4) - 2023-10-15

--- a/packages/contracts/src/core/error-handler.ts
+++ b/packages/contracts/src/core/error-handler.ts
@@ -16,15 +16,15 @@ export interface ErrorHandler {
   /**
    * Handle the given error.
    */
-  handle(ctx: HttpContext, error: Error): Promise<void>
+  handle(error: Error, ctx: HttpContext): Promise<void>
 
   /**
    * Report an error.
    */
-  report(context: HttpContext, error: Error): void | Promise<void>
+  report(error: Error, ctx: HttpContext): void | Promise<void>
 
   /**
    * Render an error into an HTTP response.
    */
-  render(context: HttpContext, error: Error): Promise<any>
+  render(error: Error, ctx: HttpContext): Promise<any>
 }

--- a/packages/core/test/error-handler.js
+++ b/packages/core/test/error-handler.js
@@ -183,7 +183,7 @@ test('calls report callbacks', async () => {
 
   class CustomErrorHandler extends ErrorHandler {
     register () {
-      this.reportable((_, error) => {
+      this.reportable(error => {
         reportedError = error
       })
     }
@@ -215,7 +215,7 @@ test('report callbacks can stop the reportable chain', async () => {
         .reportable(() => {
           return true
         })
-        .reportable((_ctx, error) => {
+        .reportable(error => {
           reportedError = error
         })
     }
@@ -448,7 +448,7 @@ class ReportedError extends ReportingError {
 }
 
 class RenderError extends Error {
-  render (ctx, error) {
+  render (error, ctx) {
     return ctx.response.payload({
       message: error.message,
       foo: 'bar',

--- a/packages/http/src/middleware/handle-error.ts
+++ b/packages/http/src/middleware/handle-error.ts
@@ -10,16 +10,16 @@ export class HandleErrorMiddleware extends Middleware {
     try {
       await next()
     } catch (error: any) {
-      await this.handleError(ctx, error)
+      await this.handleError(error, ctx)
     }
   }
 
   /**
    * Process the given `error` and HTTP `ctx` using the error handler.
    */
-  private async handleError (ctx: HttpContext, error: Error): Promise<void> {
+  private async handleError (error: Error, ctx: HttpContext): Promise<void> {
     if (this.app.hasBinding('error.handler')) {
-      return await this.app.make<ErrorHandler>('error.handler').handle(ctx, error)
+      return await this.app.make<ErrorHandler>('error.handler').handle(error, ctx)
     }
 
     throw error

--- a/packages/http/test/helpers/error-handler.js
+++ b/packages/http/test/helpers/error-handler.js
@@ -1,6 +1,6 @@
 
 export default class ErrorHandler {
-  handle (ctx, error) {
+  handle (error, ctx) {
     // console.log('Received error in testing error handler', { error })
 
     ctx.response.status(error.status || error.statusCode || 500)

--- a/packages/session/test/helpers/error-handler.js
+++ b/packages/session/test/helpers/error-handler.js
@@ -2,9 +2,9 @@
 import { ErrorHandler as Handler } from '@supercharge/core'
 
 export default class ErrorHandler extends Handler {
-  handle (ctx, error) {
+  handle (error, ctx) {
     // console.error('Received error in testing error handler', { error })
 
-    return super.handle(ctx, error)
+    return super.handle(error, ctx)
   }
 }


### PR DESCRIPTION
This pull request switches the parameters of the error `report`, `handle`, `render` method:

```ts
// before
handle(ctx: HttpContext, error: Error)
report(ctx: HttpContext, error: Error)
render(ctx: HttpContext, error: Error)

// now
handle(error: Error, ctx: HttpContext)
report(error: Error, ctx: HttpContext)
render(error: Error, ctx: HttpContext)
```