### PR TITLE
Hashing: add type for supported algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `@supercharge/contracts`
     - add `HttpDefaultRequestHeaders` and `HttpDefaultRequestHeader` interfaces: these are strict contracts for HTTP headers allowing IntelliSense for individual headers. IntelliSense is not supported on Node.js’s `IncomingHttpHeaders` interface because it contains an index signature which opens the interfaces to basically anything … the newly added interfaces are strict for allowed keys
     - add `HttpRequestHeaders` and `HttpRequestHeader` interfaces: `HttpRequestHeaders` is an interface to be used by developers for augmentation to add custom, project-specific request headers. For example, this can be used to add headers for rate limiting
+    - add `HashAlgorithms` interface and `HashAlgorithm` type: `HashAlgorithms` is an interface providing the supported hash algorithms of Node.js v20 for IntelliSense, improving the developer experience when working with hashes
 - `@supercharge/hashing`
     - add `createHash` method: create a Node.js `Hash` instance for a given input
     - add `md5` method: create a Node.js MD5 hash

--- a/packages/contracts/src/hashing/base-hasher.ts
+++ b/packages/contracts/src/hashing/base-hasher.ts
@@ -1,6 +1,7 @@
 
-import type { BinaryLike, Encoding, Hash } from 'node:crypto'
+import { HashAlgorithm } from './hash-algorithms.js'
 import { HashBuilderCallback } from './hash-builder.js'
+import type { BinaryLike, Encoding, Hash } from 'node:crypto'
 
 export interface BaseHasher {
   /**
@@ -8,7 +9,7 @@ export interface BaseHasher {
    * and the related `input` with (optional) `inputEncoding`. When `input`
    * is a string and `inputEncoding` is omitted, it defaults to `utf8`.
    */
-  createHash (algorithm: string, input: string | BinaryLike, inputEncoding?: Encoding): Hash
+  createHash (algorithm: HashAlgorithm, input: string | BinaryLike, inputEncoding?: Encoding): Hash
 
   /**
    * Returns an MD5 hash instance for the given `content`.

--- a/packages/contracts/src/hashing/hash-algorithms.ts
+++ b/packages/contracts/src/hashing/hash-algorithms.ts
@@ -1,0 +1,87 @@
+
+/**
+ * This `HashAlgorithms` interface defines the supported Node.js hash algorithms.
+ * It can also be used in userland projects to extend the default list of hash
+ * algorithms, in case this interface doesn’t expose the values you wanted.
+ *
+ * You can find out which hash algorithms are supported in your environment
+ * by using Node.js’ `crypto` module. If you’re using another runtime, it
+ * should provide a way to detect supported hash algorithms, too.
+ *
+ * @see https://futurestud.io/tutorials/node-js-retrieve-the-list-of-supported-hash-algorithms
+ *
+ * If you’re wondering why we’re not using a TypeScript type alias here: they
+ * don’t allow declaration merging, meaning that developers can’t add their
+ * own algorithms to the existing type. And that’s usually what you want.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/28078
+ *
+ * You may extend this `HashAlgorithms` interface in your own project like this:
+ *
+ * @example
+ *
+ * ```ts
+ *  declare module '@supercharge/contracts' {
+ *    export interface HashAlgorithms {
+ *      'algorithm': 'algorithm'
+ *    }
+ *  }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface HashAlgorithms {
+  'RSA-MD5': 'RSA-MD5'
+  'RSA-RIPEMD160': 'RSA-RIPEMD160'
+  'RSA-SHA1': 'RSA-SHA1'
+  'RSA-SHA1-2': 'RSA-SHA1-2'
+  'RSA-SHA224': 'RSA-SHA224'
+  'RSA-SHA256': 'RSA-SHA256'
+  'RSA-SHA3-224': 'RSA-SHA3-224'
+  'RSA-SHA3-256': 'RSA-SHA3-256'
+  'RSA-SHA3-384': 'RSA-SHA3-384'
+  'RSA-SHA3-512': 'RSA-SHA3-512'
+  'RSA-SHA384': 'RSA-SHA384'
+  'RSA-SHA512': 'RSA-SHA512'
+  'RSA-SHA512/224': 'RSA-SHA512/224'
+  'RSA-SHA512/256': 'RSA-SHA512/256'
+  'RSA-SM3': 'RSA-SM3'
+  'blake2b512': 'blake2b512'
+  'blake2s256': 'blake2s256'
+  'id-rsassa-pkcs1-v1_5-with-sha3-224': 'id-rsassa-pkcs1-v1_5-with-sha3-224'
+  'id-rsassa-pkcs1-v1_5-with-sha3-256': 'id-rsassa-pkcs1-v1_5-with-sha3-256'
+  'id-rsassa-pkcs1-v1_5-with-sha3-384': 'id-rsassa-pkcs1-v1_5-with-sha3-384'
+  'id-rsassa-pkcs1-v1_5-with-sha3-512': 'id-rsassa-pkcs1-v1_5-with-sha3-512'
+  'md5': 'md5'
+  'md5-sha1': 'md5-sha1'
+  'md5WithRSAEncryption': 'md5WithRSAEncryption'
+  'ripemd': 'ripemd'
+  'ripemd160': 'ripemd160'
+  'ripemd160WithRSA': 'ripemd160WithRSA'
+  'rmd160': 'rmd160'
+  'sha1': 'sha1'
+  'sha1WithRSAEncryption': 'sha1WithRSAEncryption'
+  'sha224': 'sha224'
+  'sha224WithRSAEncryption': 'sha224WithRSAEncryption'
+  'sha256': 'sha256'
+  'sha256WithRSAEncryption': 'sha256WithRSAEncryption'
+  'sha3-224': 'sha3-224'
+  'sha3-256': 'sha3-256'
+  'sha3-384': 'sha3-384'
+  'sha3-512': 'sha3-512'
+  'sha384': 'sha384'
+  'sha384WithRSAEncryption': 'sha384WithRSAEncryption'
+  'sha512': 'sha512'
+  'sha512-224': 'sha512-224'
+  'sha512-224WithRSAEncryption': 'sha512-224WithRSAEncryption'
+  'sha512-256': 'sha512-256'
+  'sha512-256WithRSAEncryption': 'sha512-256WithRSAEncryption'
+  'sha512WithRSAEncryption': 'sha512WithRSAEncryption'
+  'shake128': 'shake128'
+  'shake256': 'shake256'
+  'sm3': 'sm3'
+  'sm3WithRSAEncryption': 'sm3WithRSAEncryption'
+  'ssl3-md5': 'ssl3-md5'
+  'ssl3-sha1': 'ssl3-sha1'
+}
+
+export type HashAlgorithm = keyof HashAlgorithms

--- a/packages/contracts/src/http/request-headers.ts
+++ b/packages/contracts/src/http/request-headers.ts
@@ -37,7 +37,6 @@ export type HttpDefaultRequestHeader = keyof HttpDefaultRequestHeaders
  *  }
  * ```
  */
-
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface HttpRequestHeaders extends HttpDefaultRequestHeaders {
   //

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -24,6 +24,7 @@ export { HashBuilder, HashBuilderCallback, HashBuilderConfig } from './hashing/h
 export { HashConfig } from './hashing/config.js'
 export { BaseHasher } from './hashing/base-hasher.js'
 export { Hasher } from './hashing/hasher.js'
+export { HashAlgorithms, HashAlgorithm } from './hashing/hash-algorithms.js'
 
 export { BodyparserConfig } from './http/bodyparser-config.js'
 export { HttpConfig } from './http/config.js'

--- a/packages/hashing/src/base-hasher.ts
+++ b/packages/hashing/src/base-hasher.ts
@@ -1,7 +1,7 @@
 
 import { HashBuilder } from './hash-builder.js'
 import Crypto, { BinaryLike, Encoding, Hash } from 'node:crypto'
-import { BaseHasher as BaseHasherContract, HashBuilderCallback, HashBuilderConfig } from '@supercharge/contracts'
+import { BaseHasher as BaseHasherContract, HashAlgorithm, HashBuilderCallback, HashBuilderConfig } from '@supercharge/contracts'
 
 export class BaseHasher implements BaseHasherContract {
   /**
@@ -9,7 +9,7 @@ export class BaseHasher implements BaseHasherContract {
    * and the related `input` with (optional) `inputEncoding`. When `input`
    * is a string and `inputEncoding` is omitted, it defaults to `utf8`.
    */
-  createHash (algorithm: string, input: string | BinaryLike, inputEncoding?: Encoding): Hash {
+  createHash (algorithm: HashAlgorithm, input: string | BinaryLike, inputEncoding?: Encoding): Hash {
     return typeof input === 'string' && typeof inputEncoding === 'string'
       ? Crypto.createHash(algorithm).update(input, inputEncoding)
       : Crypto.createHash(algorithm).update(input)
@@ -50,7 +50,7 @@ export class BaseHasher implements BaseHasherContract {
    * user input. This function resolves a hash builder callback and creates
    * the hash value for the provided algorithm and i/o encoding options.
    */
-  private hash (algorithm: string, input: string | BinaryLike, inputEncodingOrHashBuilder?: Encoding | HashBuilderCallback): Hash | string {
+  private hash (algorithm: HashAlgorithm, input: string | BinaryLike, inputEncodingOrHashBuilder?: Encoding | HashBuilderCallback): Hash | string {
     if (typeof inputEncodingOrHashBuilder === 'string') {
       return this.createHash(algorithm, input, inputEncodingOrHashBuilder)
     }

--- a/packages/hashing/src/hash-manager.ts
+++ b/packages/hashing/src/hash-manager.ts
@@ -1,7 +1,7 @@
 
 import type { BinaryLike, Encoding, Hash } from 'node:crypto'
 import { Manager } from '@supercharge/manager'
-import { Application, Hasher, HashConfig, HashBuilderCallback } from '@supercharge/contracts'
+import { Application, Hasher, HashConfig, HashBuilderCallback, HashAlgorithm } from '@supercharge/contracts'
 
 export class HashManager extends Manager<Application> implements Hasher {
   /**
@@ -74,7 +74,7 @@ export class HashManager extends Manager<Application> implements Hasher {
    * and the related `input` with (optional) `inputEncoding`. When `input`
    * is a string and `inputEncoding` is omitted, it defaults to `utf8`.
    */
-  createHash (algorithm: string, input: string | BinaryLike, inputEncoding?: Encoding): Hash {
+  createHash (algorithm: HashAlgorithm, input: string | BinaryLike, inputEncoding?: Encoding): Hash {
     return this.driver().createHash(algorithm, input, inputEncoding)
   }
 


### PR DESCRIPTION
This pull request adds a `HashAlgorithms` interface providing the list of supported hash algorithms in Node.js v20. This allows us to use a type alias for a hash algorithm that improves the developer experience by providing IntelliSense when working with hashes.